### PR TITLE
Fix ballerina test groups not working when compiler plugin tests exist

### DIFF
--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -155,18 +155,10 @@ class BallerinaPlugin implements Plugin<Project> {
             }
 
             project.gradle.taskGraph.whenReady { graph ->
-                if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
-                        graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-                    if (project.hasProperty('groups')) {
-                        needSeparateTest = true
-                    }
-                    else {
-                        needSeparateTest = false
-                        needBuildWithTest = true
-                    }
-                    if (graph.hasTask(":${packageName}-ballerina:publish")) {
-                        needPublishToCentral = true
-                    }
+                if (!project.hasProperty('groups') && (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
+                        graph.hasTask(":${packageName}-ballerina:publishToMavenLocal"))) {
+                    needSeparateTest = false
+                    needBuildWithTest = true
                 } else {
                     needSeparateTest = true
                 }

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -163,8 +163,13 @@ class BallerinaPlugin implements Plugin<Project> {
             project.gradle.taskGraph.whenReady { graph ->
                 if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
                         graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-                    needSeparateTest = false
-                    needBuildWithTest = true
+                    if (project.hasProperty('groups')) {
+                        needSeparateTest = true
+                    }
+                    else {
+                        needSeparateTest = false
+                        needBuildWithTest = true
+                    }
                     if (graph.hasTask(":${packageName}-ballerina:publish")) {
                         needPublishToCentral = true
                     }


### PR DESCRIPTION
Add if condition check whether the project has the property "groups". This enables seperateTest to run testgroups which depends on "ballerina:test"