### PR TITLE
Replace revertTomlFiles Task with commitTomlFiles Task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.ballerina
-version=0.10.4-SNAPSHOT
+version=0.11.0-SNAPSHOT

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -184,7 +184,7 @@ class BallerinaPlugin implements Plugin<Project> {
         project.tasks.register('build') {
             dependsOn(project.initializeVariables)
             dependsOn(project.updateTomlFiles)
-            finalizedBy(project.revertTomlFiles)
+            finalizedBy(project.commitTomlFiles)
             dependsOn(project.test)
 
             inputs.dir projectDirectory
@@ -261,7 +261,7 @@ class BallerinaPlugin implements Plugin<Project> {
         project.tasks.register('test') {
             dependsOn(project.initializeVariables)
             dependsOn(project.updateTomlFiles)
-            finalizedBy(project.revertTomlFiles)
+            finalizedBy(project.commitTomlFiles)
             doLast {
                 if (needSeparateTest) {
                     String distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${project.extensions.ballerina.langVersion}/bin"


### PR DESCRIPTION
## Purpose
Part of https://github.com/ballerina-platform/ballerina-standard-library/issues/1746.

As a solution for the above issue, we are going to use the approach mentioned in [this comment](https://github.com/ballerina-platform/ballerina-standard-library/issues/1746#issuecomment-895915420) in the issue. Therefore, we no longer need the `revertTomlFiles` task, we are not going to revert them. But we need a new task to commit the toml files if there are any changes. It will be done via the `commitTomlFiles` task.