### PR TITLE
Fix connector build failure in Windows

### DIFF
--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -278,7 +278,7 @@ class BallerinaPlugin implements Plugin<Project> {
                                 bal pack --target-dir ${balBuildTarget}"
                         """
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                            commandLine 'cmd', '/c', "$balPackWithDocker"
+                            commandLine 'cmd', '/c', "$balPackWithDocker && exit %%ERRORLEVEL%%"
                         } else {
                             commandLine 'sh', '-c', "$balPackWithDocker"
                         }
@@ -321,7 +321,7 @@ class BallerinaPlugin implements Plugin<Project> {
                                         bal push ${balBuildTarget}/bala/${packageOrg}-${packageName}-${platform}-${balaVersion}.bala"
                                 """
                                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                                    commandLine 'cmd', '/c', "$balPushWithDocker"
+                                    commandLine 'cmd', '/c', "$balPushWithDocker && exit %%ERRORLEVEL%%"
                                 } else {
                                     commandLine 'sh', '-c', "$balPushWithDocker"
                                 }
@@ -383,10 +383,10 @@ class BallerinaPlugin implements Plugin<Project> {
                                 -v $projectDirectory:/home/ballerina/$parentDirectory.name/$projectDirectory.name \
                                 ballerina/ballerina:$ballerinaDockerTag \
                                 /bin/sh -c "cd $parentDirectory.name/$projectDirectory.name && \
-                                $balJavaDebugParam bal test ${graalvmFlag} ${parallelTestFlag} ${testCoverageParams} ${groupParams} ${disableGroups} ${debugParams}&& exit %%ERRORLEVEL%% "
+                                $balJavaDebugParam bal test ${graalvmFlag} ${parallelTestFlag} ${testCoverageParams} ${groupParams} ${disableGroups} ${debugParams}"
                         """
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                            commandLine 'cmd', '/c', "$balTestWithDocker"
+                            commandLine 'cmd', '/c', "$balTestWithDocker && exit %%ERRORLEVEL%%"
                         } else {
                             commandLine 'sh', '-c', "$balTestWithDocker"
                         }
@@ -413,7 +413,7 @@ class BallerinaPlugin implements Plugin<Project> {
                         /bin/sh -c "find /home/ballerina/$parentDirectory.name -type d -name 'build' -exec rm -rf {} + && find /home/ballerina/$parentDirectory.name -type d -name 'target' -exec rm -rf {} +"
                     """
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                        commandLine 'cmd', '/c', "$deleteUsingDocker"
+                        commandLine 'cmd', '/c', "$deleteUsingDocker && exit %%ERRORLEVEL%%"
                     } else {
                         commandLine 'sh', '-c', "$deleteUsingDocker"
                     }

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -383,7 +383,7 @@ class BallerinaPlugin implements Plugin<Project> {
                                 -v $projectDirectory:/home/ballerina/$parentDirectory.name/$projectDirectory.name \
                                 ballerina/ballerina:$ballerinaDockerTag \
                                 /bin/sh -c "cd $parentDirectory.name/$projectDirectory.name && \
-                                $balJavaDebugParam bal test ${graalvmFlag} ${parallelTestFlag} ${testCoverageParams} ${groupParams} ${disableGroups} ${debugParams}"
+                                $balJavaDebugParam bal test ${graalvmFlag} ${parallelTestFlag} ${testCoverageParams} ${groupParams} ${disableGroups} ${debugParams}&& exit %%ERRORLEVEL%% "
                         """
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                             commandLine 'cmd', '/c', "$balTestWithDocker"

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -431,7 +431,7 @@ class BallerinaPlugin implements Plugin<Project> {
         def excludedVariables = ["PATH", "JAVA_HOME", "HOME"]
         def envVariables = System.getenv()
         envVariables.each { key, value ->
-            if (!excludedVariables.contains(key)) {
+            if (!excludedVariables.contains(key) && !key.startsWith("=")) {
                 dockerEnvFileWriter.println("$key=$value")
             }
         }


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#6664](https://github.com/ballerina-platform/ballerina-library/issues/6664)

Following are the findings related to this issue:
- When running the build, the docker command fails silently and due to that FileNotFoundException is thrown when the plugin tries to extract the package `bala`
- The docker command failure was due to having invalid environment variables in the `docker.env` file

Following improvements should be done to the plugin to fix this:
- Log the docker command failure as an error in the console
- Exclude the not-required environment variables from the `docker.env` file

