### PR TITLE
Introduce support to use locally installed ballerina distribution for the connector build

### DIFF
--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -134,11 +134,12 @@ class BallerinaPlugin implements Plugin<Project> {
         }
 
         project.tasks.register('unpackStdLibs') {
+            dependsOn(project.unpackJballerinaTools)
+
             if (ballerinaExtension.isConnector) {
                 return
             }
 
-            dependsOn(project.unpackJballerinaTools)
             doLast {
                 project.configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
                     project.copy {
@@ -150,12 +151,13 @@ class BallerinaPlugin implements Plugin<Project> {
         }
 
         project.tasks.register('copyStdlibs') {
+            dependsOn(project.unpackStdLibs)
+            
             if (ballerinaExtension.isConnector) {
                 println("[Warning] skip downloading jBallerinaTools dependency: project uses locally installed Ballerina distribution to build the module")
                 return
             }
 
-            dependsOn(project.unpackStdLibs)
             doLast {
                 /* Standard Libraries */
                 project.configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -91,11 +91,7 @@ class BallerinaPlugin implements Plugin<Project> {
                 return
             }
 
-            if (ballerinaExtension.langVersion == null) {
-                jbalTools("org.ballerinalang:jballerina-tools:${ballerinaExtension.langVersion}") {
-                    transitive = false
-                }
-            } else {
+            if (ballerinaExtension.langVersion != null) {
                 jbalTools("org.ballerinalang:jballerina-tools:${ballerinaExtension.langVersion}") {
                     transitive = false
                 }

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -245,11 +245,6 @@ class BallerinaPlugin implements Plugin<Project> {
                 return
             }
 
-            if (ignoreVersionMismatch) {
-                println("[Warn] Ignoring system-installed and configured Ballerina version mismatch.")
-                return
-            }
-
             def output = new ByteArrayOutputStream()
             def error = new ByteArrayOutputStream()
 
@@ -279,6 +274,10 @@ class BallerinaPlugin implements Plugin<Project> {
             def configuredVersion = getProjectBalVersion(project)
 
             if (installedVersion != configuredVersion) {
+                if (ignoreVersionMismatch) {
+                    println("[Warn] Ignoring Ballerina version mismatch. Expected: $configuredVersion, but found: $installedVersion.")
+                    return
+                }
                 throw new GradleException("Ballerina version mismatch. Expected: $configuredVersion, but found: $installedVersion, hence exiting")
             }
 

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -260,15 +260,15 @@ class BallerinaPlugin implements Plugin<Project> {
             }
 
             def versionOutput = output.toString()
-            def installedVersion = ""
-            try {
-                def balVersion = versionOutput.split("\n")[0]
-                installedVersion = balVersion
-                        .replaceAll("Ballerina ", '')
-                        .replaceAll("\\(Swan Lake Update \\d+\\)", '')
-                        .replaceAll("\\s+", '')
-            } catch (Exception e) {
-                throw new GradleException("Failed to parse the Ballerina version: $versionOutput", e)
+            def balVersion = versionOutput.split("\n")[0]
+            def installedVersion = balVersion
+                    .replaceAll("Ballerina ", '')
+                    .replaceAll("\\(Swan Lake Update \\d+\\)", '')
+                    .replaceAll("\\s+", '')
+
+            def balVersionPattern = ~/^\d{4}\.\d+\.\d+$/
+            if (!balVersionPattern.matcher(installedVersion).matches()) {
+                throw new GradleException("Failed to parse the Ballerina version. Balllerina CLI output: $versionOutput Extracted version:$installedVersion")
             }
 
             def configuredVersion = project.findProperty('ballerinaLangVersion')

--- a/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
+++ b/src/main/groovy/io/ballerina/plugin/BallerinaPlugin.groovy
@@ -152,7 +152,7 @@ class BallerinaPlugin implements Plugin<Project> {
 
         project.tasks.register('copyStdlibs') {
             dependsOn(project.unpackStdLibs)
-            
+
             if (ballerinaExtension.isConnector) {
                 println("[Warning] skip downloading jBallerinaTools dependency: project uses locally installed Ballerina distribution to build the module")
                 return


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#166](https://github.com/ballerina-platform/plugin-gradle/issues/166)

## Example usage
- Default connector build
    ```sh
        ./gradlew clean build
    ```
- Connector build by ignoring version mismatch
    ```sh
        ./gradlew clean build -PignoreVersionMismatch
    ```